### PR TITLE
Compensated for numbers without commas

### DIFF
--- a/content.js
+++ b/content.js
@@ -14,19 +14,19 @@
     const currencyPatterns = {
         USD: {
             symbols: ['$', 'USD', 'usd'],
-            regex: /\$\s?(\d+(?:,\d{3})*(?:\.\d+)?)\s?\b(thousand|million|billion|trillion)\b|\$\s?(\d+(?:,\d{3})*(?:\.\d+)?)\s?([kKmMbBtT])|(\d+(?:,\d{3})*(?:\.\d+)?)\s?\b(thousand|million|billion|trillion)\b\s?USD|(\d+(?:,\d{3})*(?:\.\d+)?)\s?([kKmMbBtT])\s?USD|\$\s?(\d{1,3}(?:,\d{3})*(?:\.\d+)?)(?!\w)|(?<!\w)(\d{1,3}(?:,\d{3})*(?:\.\d+)?)\s?USD/gi
+            regex: /\$\s?(\d+(?:,\d{3})*(?:\.\d+)?)\s?\b(thousand|million|billion|trillion)\b|\$\s?(\d+(?:,\d{3})*(?:\.\d+)?)\s?([kKmMbBtT])|(\d+(?:,\d{3})*(?:\.\d+)?)\s?\b(thousand|million|billion|trillion)\b\s?USD|(\d+(?:,\d{3})*(?:\.\d+)?)\s?([kKmMbBtT])\s?USD|\$\s?(\d+(?:,\d{3})*(?:\.\d+)?)(?!\w)|(?<!\w)(\d+(?:,\d{3})*(?:\.\d+)?)\s?USD/gi
         },
         EUR: {
             symbols: ['€', 'EUR', 'eur'],
-            regex: /€\s?(\d+(?:,\d{3})*(?:\.\d+)?)\s?\b(thousand|million|billion|trillion)\b|€\s?(\d+(?:,\d{3})*(?:\.\d+)?)\s?([kKmMbBtT])|(\d+(?:,\d{3})*(?:\.\d+)?)\s?\b(thousand|million|billion|trillion)\b\s?EUR|(\d+(?:,\d{3})*(?:\.\d+)?)\s?([kKmMbBtT])\s?EUR|€\s?(\d{1,3}(?:,\d{3})*(?:\.\d+)?)(?!\w)|(?<!\w)(\d{1,3}(?:,\d{3})*(?:\.\d+)?)\s?EUR/gi
+            regex: /€\s?(\d+(?:,\d{3})*(?:\.\d+)?)\s?\b(thousand|million|billion|trillion)\b|€\s?(\d+(?:,\d{3})*(?:\.\d+)?)\s?([kKmMbBtT])|(\d+(?:,\d{3})*(?:\.\d+)?)\s?\b(thousand|million|billion|trillion)\b\s?EUR|(\d+(?:,\d{3})*(?:\.\d+)?)\s?([kKmMbBtT])\s?EUR|€\s?(\d+(?:,\d{3})*(?:\.\d+)?)(?!\w)|(?<!\w)(\d+(?:,\d{3})*(?:\.\d+)?)\s?EUR/gi
         },
         GBP: {
             symbols: ['£', 'GBP', 'gbp'],
-            regex: /£\s?(\d+(?:,\d{3})*(?:\.\d+)?)\s?\b(thousand|million|billion|trillion)\b|£\s?(\d+(?:,\d{3})*(?:\.\d+)?)\s?([kKmMbBtT])|(\d+(?:,\d{3})*(?:\.\d+)?)\s?\b(thousand|million|billion|trillion)\b\s?GBP|(\d+(?:,\d{3})*(?:\.\d+)?)\s?([kKmMbBtT])\s?GBP|£\s?(\d{1,3}(?:,\d{3})*(?:\.\d+)?)(?!\w)|(?<!\w)(\d{1,3}(?:,\d{3})*(?:\.\d+)?)\s?GBP/gi
+            regex: /£\s?(\d+(?:,\d{3})*(?:\.\d+)?)\s?\b(thousand|million|billion|trillion)\b|£\s?(\d+(?:,\d{3})*(?:\.\d+)?)\s?([kKmMbBtT])|(\d+(?:,\d{3})*(?:\.\d+)?)\s?\b(thousand|million|billion|trillion)\b\s?GBP|(\d+(?:,\d{3})*(?:\.\d+)?)\s?([kKmMbBtT])\s?GBP|£\s?(\d+(?:,\d{3})*(?:\.\d+)?)(?!\w)|(?<!\w)(\d+(?:,\d{3})*(?:\.\d+)?)\s?GBP/gi
         },
         JPY: {
             symbols: ['¥', 'JPY', 'jpy'],
-            regex: /¥\s?(\d+(?:,\d{3})*)\s?\b(thousand|million|billion|trillion)\b|¥\s?(\d+(?:,\d{3})*)\s?([kKmMbBtT])|(\d+(?:,\d{3})*)\s?\b(thousand|million|billion|trillion)\b\s?JPY|(\d+(?:,\d{3})*)\s?([kKmMbBtT])\s?JPY|¥\s?(\d{1,3}(?:,\d{3})*)(?!\w)|(?<!\w)(\d{1,3}(?:,\d{3})*)\s?JPY/gi
+            regex: /¥\s?(\d+(?:,\d{3})*)\s?\b(thousand|million|billion|trillion)\b|¥\s?(\d+(?:,\d{3})*)\s?([kKmMbBtT])|(\d+(?:,\d{3})*)\s?\b(thousand|million|billion|trillion)\b\s?JPY|(\d+(?:,\d{3})*)\s?([kKmMbBtT])\s?JPY|¥\s?(\d+(?:,\d{3})*)(?!\w)|(?<!\w)(\d+(?:,\d{3})*)\s?JPY/gi
         }
     };
 

--- a/test.html
+++ b/test.html
@@ -40,6 +40,7 @@
     <div class="test-section">
         <div class="test-title">Regular Prices (should still work):</div>
         <p>Regular prices: <span class="price">$19.99</span>, <span class="price">€25.50</span>, <span class="price">£15.99</span></p>
+        <p>Prices with no decimal: <span class="price">$2500</span>, <span class="price">€50</span>, <span class="price">£10000</span></p>
         <p>Large regular: <span class="price">$1,234,567.89</span></p>
     </div>
     


### PR DESCRIPTION
Regular prices without commas (e.g. $3500) were not converting.  Regex has been updated to compensate for these scenarios